### PR TITLE
Remove faulty HTML report params

### DIFF
--- a/lib/kb_muscle/kb_muscleImpl.py
+++ b/lib/kb_muscle/kb_muscleImpl.py
@@ -815,10 +815,7 @@ class kb_muscle:
                                     'description':'MUSCLE_nuc MSA'}],
                 #'message': '',
                 'message': clw_buf_str,
-                'direct_html': '',
-                'direct_html_index': None,
                 'file_links': [],
-                'html_links': [],
                 'workspace_name': params['workspace_name'],
                 'report_object_name': reportName
                 }
@@ -1475,10 +1472,7 @@ class kb_muscle:
                                     'description':'MUSCLE_prot MSA'}],
                 #'message': '',
                 'message': clw_buf_str,
-                'direct_html': '',
-                'direct_html_index': None,
                 'file_links': [],
-                'html_links': [],
                 'workspace_name': params['workspace_name'],
                 'report_object_name': reportName
                 }


### PR DESCRIPTION
"direct_html_index" is not a valid param name which is causing the app to fail. You arn't showing HTML anyway so I'm just going to remove the boilerplate.